### PR TITLE
Introduced BaseJob

### DIFF
--- a/src/sqt/execution.py
+++ b/src/sqt/execution.py
@@ -1,14 +1,18 @@
 from qiskit import QuantumCircuit
 from qiskit.providers.backend import BackendV2 as Backend
-from qiskit_ibm_runtime import RuntimeJobV2 as RuntimeJob
+
+from sqt.job import BaseJob
 
 
 def submit(
     circuits: list[QuantumCircuit],
     backend: Backend,
+    hub: str,
+    group: str,
+    project: str,
     tags: list[str] | None = None,
     **kwargs,
-) -> RuntimeJob:
+) -> BaseJob:
     """Submit the given circuits on the backend and returns.
 
     This function sumits the given circuits to the backend, using a job manager if
@@ -30,12 +34,16 @@ def submit(
         Refer to the documentation on :func:`qiskit.compiler.assemble`
         for details on these arguments.
     """
-    return backend.run(circuits, dynamic=False, job_tags=tags, **kwargs)  # type: ignore
+    job = backend.run(circuits, dynamic=False, job_tags=tags, **kwargs)
+    return BaseJob.from_job(job, hub, group, project)  # type: ignore
 
 
 def execute(
     circuits: list[QuantumCircuit],
     backend: Backend,
+    hub: str,
+    group: str,
+    project: str,
     tags: list[str] | None = None,
     **kwargs,
 ):
@@ -62,5 +70,5 @@ def execute(
         Refer to the documentation on :func:`qiskit.compiler.assemble`
         for details on these arguments.
     """
-    job = submit(circuits, backend, tags, **kwargs)
+    job = submit(circuits, backend, hub, group, project, tags, **kwargs)
     return job.result()

--- a/src/sqt/job.py
+++ b/src/sqt/job.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import typing as ty
+from abc import ABC, abstractmethod
+
+from qiskit.result import Result
+from qiskit_aer.jobs import AerJob, AerJobSet
+from qiskit_ibm_runtime import QiskitRuntimeService
+from qiskit_ibm_runtime import RuntimeJobV2 as RuntimeJob
+
+
+class BaseJob(ABC):
+    @abstractmethod
+    def id(self) -> str:
+        pass
+
+    @abstractmethod
+    def result(self) -> Result:
+        pass
+
+    @abstractmethod
+    def to_dict(self) -> ty.Mapping[str, ty.Any]:
+        pass
+
+    @abstractmethod
+    def wait_for_completion(self) -> None:
+        pass
+
+    @staticmethod
+    def from_dict(d: ty.Mapping[str, ty.Any]) -> "BaseJob":
+        if "id" in d:
+            return RemoteJob.from_dict(d)
+        else:
+            return LocalJob.from_dict(d)
+
+    @staticmethod
+    def from_job(
+        job: RuntimeJob | AerJob | AerJobSet, hub: str, group: str, project: str
+    ) -> "BaseJob":
+        if isinstance(job, RuntimeJob):
+            return BaseJob._from_ibmq_runtime_job(job, hub, group, project)
+        elif isinstance(job, (AerJob, AerJobSet)):
+            return BaseJob._from_aer_job(job)
+        else:
+            raise RuntimeError(f"Unsupported job type: {type(job)}")
+
+    @staticmethod
+    def _from_ibmq_runtime_job(
+        job: RuntimeJob, hub: str, group: str, project: str
+    ) -> "RemoteJob":
+        return RemoteJob(job.job_id(), hub, group, project)
+
+    @staticmethod
+    def _from_aer_job(job: AerJob | AerJobSet) -> "LocalJob":
+        return LocalJob(job.result())
+
+
+class LocalJob(BaseJob):
+    def __init__(self, result: Result) -> None:
+        super().__init__()
+
+        self._result = result
+
+    def id(self) -> str:
+        return self._result.job_id
+
+    def result(self):
+        return self._result
+
+    def to_dict(self) -> ty.Mapping[str, ty.Any]:
+        return {"result": self._result.to_dict()}
+
+    @staticmethod
+    def from_dict(d: ty.Mapping[str, ty.Any]) -> "LocalJob":
+        return LocalJob(Result.from_dict(d["result"]))
+
+    def wait_for_completion(self) -> None:
+        return
+
+
+class RemoteJob(BaseJob):
+    def __init__(self, id: str, hub: str, group: str, project: str) -> None:
+        super().__init__()
+        self._id = id
+        self._hub = hub
+        self._group = group
+        self._project = project
+        self._service = None
+
+    def id(self) -> str:
+        return self._id
+
+    def result(self) -> Result:
+        return self._get_service().job(self.id()).result()
+
+    def _get_service(self) -> QiskitRuntimeService:
+        if self._service is None:
+            self._service = QiskitRuntimeService(
+                channel="ibm_quantum",
+                instance=f"{self._hub}/{self._group}/{self._project}",
+            )
+            if not self._service.active_account():
+                raise RuntimeError(
+                    f"Could not load account with '{self._hub}' '{self._group}' '{self._project}'."
+                )
+        return self._service
+
+    def to_dict(self) -> ty.Mapping[str, ty.Any]:
+        return {
+            "id": self._id,
+            "hub": self._hub,
+            "group": self._group,
+            "project": self._project,
+        }
+
+    @staticmethod
+    def from_dict(d: ty.Mapping[str, ty.Any]) -> "RemoteJob":
+        return RemoteJob(d["id"], d["hub"], d["group"], d["project"])
+
+    def wait_for_completion(self) -> None:
+        self._get_service().job(self.id()).wait_for_final_state()


### PR DESCRIPTION
This PR introduces `BaseJob` and two subclasses to abstract away details (e.g., is the job locally simulated or submitted to an online service?).

It fixes #5 as `.result()` is now only called when necessary and also fixes #6.