### PR TITLE
Fix wrong type used in `job.py`

### DIFF
--- a/src/sqt/job.py
+++ b/src/sqt/job.py
@@ -5,8 +5,7 @@ from abc import ABC, abstractmethod
 
 from qiskit.result import Result
 from qiskit_aer.jobs import AerJob, AerJobSet
-from qiskit_ibm_runtime import QiskitRuntimeService
-from qiskit_ibm_runtime import RuntimeJobV2 as RuntimeJob
+from qiskit_ibm_runtime import QiskitRuntimeService, RuntimeJob
 
 
 class BaseJob(ABC):


### PR DESCRIPTION
Fixes #8 by using the correct job type.